### PR TITLE
Remove unused -v option

### DIFF
--- a/lib/meetup_thingy/app.rb
+++ b/lib/meetup_thingy/app.rb
@@ -20,7 +20,6 @@ module MeetupThingy
 
     option :input, aliases: '-i', required: true, type: :string
     option :output, aliases: '-o', required: true, type: :string
-    option :version, aliases: '-v', required: false, type: :string
 
     def extract_events
       output_file = options[:output]


### PR DESCRIPTION
The `-v` option is covered by the `--version` and `-v` `map` statements on lines 33 and 34.